### PR TITLE
Export scenesid instead of dllList

### DIFF
--- a/inst/python/dllLandsat.py
+++ b/inst/python/dllLandsat.py
@@ -5,7 +5,7 @@ def dllLandsat(queuefolder, queuefile, tmpfolder, logfile, ext, starttime, endti
     from shapely.geometry import Polygon
     import re
     import os
-    
+
     # Search scenes of interest over the study area
     # define area of interest
     xmin = ext[0]
@@ -14,7 +14,7 @@ def dllLandsat(queuefolder, queuefile, tmpfolder, logfile, ext, starttime, endti
     ymax = ext[3]
     pol = Polygon([[xmin,ymin],[xmax,ymin],[xmax,ymax],[xmin,ymax],[xmin,ymin]])
     # define time period of interest
-    begin = datetime(int(starttime[0]), int(starttime[1]), int(starttime[2])) 
+    begin = datetime(int(starttime[0]), int(starttime[1]), int(starttime[2]))
     end = datetime(int(endtime[0]), int(endtime[1]), int(endtime[2]))
     # search scenes in catalog that fulfill requirements
     catalog = Catalog()
@@ -26,19 +26,19 @@ def dllLandsat(queuefolder, queuefile, tmpfolder, logfile, ext, starttime, endti
         tiers=tiers,
         maxcloud=cld
     )
-    
+
     # check which scenes are not downloaded yet
     scenesid = [item['product_id'] for item in scenes]# product id of scenes that match the query
     queue_file = open(os.path.join(queuefolder, queuefile), "r")
     lines = re.findall(r'(\/.*?\.[\w:]+)', queue_file.read())
     queue = [os.path.splitext(os.path.basename(x))[0] for x in lines]# list of scenes that are already in the queue
-    
+
     dllList = [s for s in scenesid if all(xs not in s for xs in queue)] # items that match the query but are not in     queue
-    
+
     # Download scenes
     # dllFiles = [Product(x).download(out_dir= tmpfolder) for x in dllList]#Downloaded files
     dllFiles = [checkdll(x, tmpfolder, logfile) for x in dllList]#Downloaded files
-    return dllList
+    return scenesid
 
 def checkdll(x, out_dir, logfile):
     from pylandsat import Product

--- a/inst/python/dllLandsat.py
+++ b/inst/python/dllLandsat.py
@@ -33,12 +33,12 @@ def dllLandsat(queuefolder, queuefile, tmpfolder, logfile, ext, starttime, endti
     lines = re.findall(r'(\/.*?\.[\w:]+)', queue_file.read())
     queue = [os.path.splitext(os.path.basename(x))[0] for x in lines]# list of scenes that are already in the queue
 
-    dllList = [s for s in scenesid if all(xs not in s for xs in queue)] # items that match the query but are not in     queue
+    dllList = [s for s in scenesid if all(xs not in s for xs in queue)] # items that match the query but are not already in queue
 
     # Download scenes
     # dllFiles = [Product(x).download(out_dir= tmpfolder) for x in dllList]#Downloaded files
     dllFiles = [checkdll(x, tmpfolder, logfile) for x in dllList]#Downloaded files
-    return scenesid
+    return dllList, scenesid # If called from R, dllList <- output[[1]], scenesid <- output[[2]]
 
 def checkdll(x, out_dir, logfile):
     from pylandsat import Product

--- a/vignettes/make_Landsat_cube.Rmd
+++ b/vignettes/make_Landsat_cube.Rmd
@@ -100,6 +100,8 @@ makeParFile(paramfolder, file.path(paramfolder, paramfile), FILE_QUEUE = file.pa
 # Search Landsat scenes, download and add to queue
 ```{r Landsat}
 LSscenes <- dllLS(l1folder, queuefolder, queuefile, tmpfolder, landsatlogfile, ext, starttime, endtime, sensors, tiers, cld)
+dllList <- LSscenes[[1]] # The scenes that have actually been downloaded in this execution
+scenes <- LSscenes[[2]] # The total list of scenes to be processed
 ```
 
 # Add Sentinel-2 data to queue
@@ -128,6 +130,6 @@ dllWVP(wvpfolder, logfile = wvplogfile)
 - generate vrt
 - summarize log files of all scenes
 ```{r process}
-Landsat2L2(paramfolder, paramfile, l2folder, LSscenes, logfolder, Sskiplogfile, Ssuccesslogfile, Smissionlogfile, Sotherlogfile)
+Landsat2L2(paramfolder, paramfile, l2folder, dllList, logfolder, Sskiplogfile, Ssuccesslogfile, Smissionlogfile, Sotherlogfile)
 ```
 


### PR DESCRIPTION
`dllList` changes depending on what files are present in the drive. `scenesid` doesn't.

This fixes issue #20